### PR TITLE
Update battery unit

### DIFF
--- a/custom_components/schlage/sensor.py
+++ b/custom_components/schlage/sensor.py
@@ -33,7 +33,7 @@ class BatterySensor(CoordinatorEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = PERCENTAGE
 
     def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         super().__init__(coordinator)


### PR DESCRIPTION
Update battery unit to remove unit warning from Home Assistant in logs