### PR TITLE
Populate the `changed_by` attribute on the lock.

### DIFF
--- a/custom_components/schlage/sensor.py
+++ b/custom_components/schlage/sensor.py
@@ -43,7 +43,7 @@ class BatterySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def _lock(self) -> Lock:
-        return self.coordinator.data[self.device_id]
+        return self.coordinator.data[self.device_id].lock
 
     def _update_attrs(self):
         self._attr_native_value = self._lock.battery_level

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,14 +1,53 @@
 """Test schlage lock."""
+from datetime import datetime
 from unittest.mock import create_autospec, patch
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 import pyschlage
+from pyschlage.log import LockLog
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.schlage.const import DOMAIN
 
 from .const import MOCK_CONFIG
+
+
+async def test_changed_by(hass, bypass_auth_init):
+    """Test parsing of logs for the changed_by attribute."""
+    mock_lock = create_autospec(pyschlage.Lock)
+    mock_lock.configure_mock(
+        device_id="test",
+        name="Vault Door",
+        model_name="<model-name>",
+        is_locked=False,
+        is_jammed=False,
+        battery_level=0,
+        firmware_version="1.0",
+    )
+    mock_lock.logs.return_value = [
+        create_autospec(
+            LockLog,
+            created_at=datetime(2023, 1, 1, 0, 0, 0),
+            message="Locked by keypad",
+        ),
+        create_autospec(
+            LockLog,
+            created_at=datetime(2023, 1, 1, 1, 0, 0),
+            message="Unlocked by thumbturn",
+        ),
+    ]
+    with patch("pyschlage.Schlage.locks", return_value=[mock_lock]):
+        entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert DOMAIN in hass.config_entries.async_domains()
+
+        lock_device = hass.states.get("lock.vault_door_lock")
+        assert lock_device is not None
+        assert lock_device.attributes.get("changed_by") == "thumbturn"
 
 
 async def test_lock_services(hass, bypass_auth_init):
@@ -23,6 +62,7 @@ async def test_lock_services(hass, bypass_auth_init):
         battery_level=0,
         firmware_version="1.0",
     )
+    mock_lock.logs.return_value = []
 
     with patch("pyschlage.Schlage.locks", return_value=[mock_lock]):
         entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")


### PR DESCRIPTION
This is pulled from the last log entry that matches the current lock state.