### PR TITLE
Add additional details to the changed_by attribute

### DIFF
--- a/custom_components/schlage/manifest.json
+++ b/custom_components/schlage/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dknowles2/ha-schlage/issues",
   "requirements": [
-    "pyschlage==2023.2.2"
+    "pyschlage==2023.3.1"
   ],
   "version": "2023.2.1"
 }

--- a/custom_components/schlage/sensor.py
+++ b/custom_components/schlage/sensor.py
@@ -24,7 +24,10 @@ async def async_setup_entry(
     """Set up sensors based on a config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
-        [BatterySensor(coordinator, device_id) for device_id in coordinator.data.keys()]
+        [
+            BatterySensor(coordinator, device_id)
+            for device_id in coordinator.data.locks.keys()
+        ]
     )
 
 
@@ -43,7 +46,7 @@ class BatterySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def _lock(self) -> Lock:
-        return self.coordinator.data[self.device_id].lock
+        return self.coordinator.data.locks[self.device_id].lock
 
     def _update_attrs(self):
         self._attr_native_value = self._lock.battery_level

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest==7.2.1
 pytest-asyncio==0.20.3
 pytest-homeassistant-custom-component==0.13.3
-pyschlage==2023.2.2
+pyschlage==2023.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def skip_notifications_fixture():
 @pytest.fixture(name="bypass_get_data")
 def bypass_get_data_fixture():
     """Skip calls to get data from API."""
-    with patch("pyschlage.Schlage.locks"):
+    with patch("pyschlage.Schlage.locks"), patch("pyschlage.Schlage.users"):
         yield
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,8 +4,12 @@ from unittest.mock import create_autospec, patch
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
-import pyschlage
+from pyschlage.code import AccessCode
+from pyschlage.lock import Lock
 from pyschlage.log import LockLog
+from pyschlage.user import User
+import pytest
+from pytest import fixture
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.schlage.const import DOMAIN
@@ -13,58 +17,146 @@ from custom_components.schlage.const import DOMAIN
 from .const import MOCK_CONFIG
 
 
-async def test_changed_by(hass, bypass_auth_init):
+def make_mock(cls, **kwargs):
+    """Wrapper around create_autospec & configure_mock.
+
+    Useful when you need to set a |name| attribute in the mock.
+    """
+    code = create_autospec(cls)
+    code.configure_mock(**kwargs)
+    return code
+
+
+@fixture
+def mock_lock(mock_access_code):
+    mock_lock = make_mock(
+        Lock,
+        device_id="test",
+        name="Vault Door",
+        model_name="<model-name>",
+        is_locked=False,
+        is_jammed=False,
+        battery_level=0,
+        firmware_version="1.0",
+    )
+    mock_lock.access_codes.return_value = [mock_access_code]
+    return mock_lock
+
+
+@fixture
+def mock_access_code():
+    yield make_mock(
+        AccessCode,
+        access_code_id="__access-code-id__",
+        name="SECRET CODE",
+    )
+
+
+@fixture
+def mock_user():
+    yield make_mock(
+        User,
+        name="robot",
+        email="robot@cyb.org",
+        user_id="__user-id__",
+    )
+
+
+class TestChangedBy:
     """Test parsing of logs for the changed_by attribute."""
-    mock_lock = create_autospec(pyschlage.Lock)
-    mock_lock.configure_mock(
-        device_id="test",
-        name="Vault Door",
-        model_name="<model-name>",
-        is_locked=False,
-        is_jammed=False,
-        battery_level=0,
-        firmware_version="1.0",
-    )
-    mock_lock.logs.return_value = [
-        create_autospec(
-            LockLog,
-            created_at=datetime(2023, 1, 1, 0, 0, 0),
-            message="Locked by keypad",
-        ),
-        create_autospec(
-            LockLog,
-            created_at=datetime(2023, 1, 1, 1, 0, 0),
-            message="Unlocked by thumbturn",
-        ),
-    ]
-    with patch("pyschlage.Schlage.locks", return_value=[mock_lock]):
-        entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-        entry.add_to_hass(hass)
 
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-        assert DOMAIN in hass.config_entries.async_domains()
+    async def test_thumbturn_unlock(self, hass, bypass_auth_init, mock_lock):
+        mock_lock.logs.return_value = [
+            create_autospec(
+                LockLog,
+                created_at=datetime(2023, 1, 1, 0, 0, 0),
+                message="Locked by keypad",
+            ),
+            create_autospec(
+                LockLog,
+                created_at=datetime(2023, 1, 1, 1, 0, 0),
+                message="Unlocked by thumbturn",
+            ),
+        ]
+        mock_locks = patch("pyschlage.Schlage.locks", return_value=[mock_lock])
+        mock_users = patch("pyschlage.Schlage.users", return_value=[])
+        with mock_locks, mock_users:
+            entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+            entry.add_to_hass(hass)
 
-        lock_device = hass.states.get("lock.vault_door_lock")
-        assert lock_device is not None
-        assert lock_device.attributes.get("changed_by") == "thumbturn"
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+            assert DOMAIN in hass.config_entries.async_domains()
+
+            lock_device = hass.states.get("lock.vault_door_lock")
+            assert lock_device is not None
+            assert lock_device.attributes.get("changed_by") == "thumbturn"
+
+    async def test_keypad_unlock(self, hass, bypass_auth_init, mock_lock):
+        mock_lock.logs.return_value = [
+            create_autospec(
+                LockLog,
+                created_at=datetime(2023, 1, 1, 0, 0, 0),
+                message="Locked by keypad",
+            ),
+            create_autospec(
+                LockLog,
+                created_at=datetime(2023, 1, 1, 1, 0, 0),
+                message="Unlocked by keypad",
+                access_code_id="__access-code-id__",
+            ),
+        ]
+        mock_locks = patch("pyschlage.Schlage.locks", return_value=[mock_lock])
+        mock_users = patch("pyschlage.Schlage.users", return_value=[])
+        with mock_locks, mock_users:
+            entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+            entry.add_to_hass(hass)
+
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+            assert DOMAIN in hass.config_entries.async_domains()
+
+            lock_device = hass.states.get("lock.vault_door_lock")
+            assert lock_device is not None
+            assert lock_device.attributes.get("changed_by") == "keypad - SECRET CODE"
+
+    async def test_mobile_device_unlock(
+        self, hass, bypass_auth_init, mock_lock, mock_user
+    ):
+        mock_lock.logs.return_value = [
+            create_autospec(
+                LockLog,
+                created_at=datetime(2023, 1, 1, 0, 0, 0),
+                message="Locked by keypad",
+            ),
+            create_autospec(
+                LockLog,
+                created_at=datetime(2023, 1, 1, 1, 0, 0),
+                message="Unlocked by mobile device",
+                accessor_id="__user-id__",
+            ),
+        ]
+        mock_locks = patch("pyschlage.Schlage.locks", return_value=[mock_lock])
+        mock_users = patch("pyschlage.Schlage.users", return_value=[mock_user])
+        with mock_locks, mock_users:
+            entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+            entry.add_to_hass(hass)
+
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+            assert DOMAIN in hass.config_entries.async_domains()
+
+            lock_device = hass.states.get("lock.vault_door_lock")
+            assert lock_device is not None
+            assert lock_device.attributes.get("changed_by") == "mobile device - robot"
 
 
-async def test_lock_services(hass, bypass_auth_init):
+async def test_lock_services(hass, bypass_auth_init, mock_lock):
     """Test lock services."""
-    mock_lock = create_autospec(pyschlage.Lock)
-    mock_lock.configure_mock(
-        device_id="test",
-        name="Vault Door",
-        model_name="<model-name>",
-        is_locked=False,
-        is_jammed=False,
-        battery_level=0,
-        firmware_version="1.0",
-    )
     mock_lock.logs.return_value = []
-
-    with patch("pyschlage.Schlage.locks", return_value=[mock_lock]):
+    mock_locks = patch("pyschlage.Schlage.locks", return_value=[mock_lock])
+    mock_users = patch("pyschlage.Schlage.users", return_value=[])
+    with mock_locks, mock_users:
         entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
         entry.add_to_hass(hass)
 


### PR DESCRIPTION
When the lock state was changed by a keypad or a mobile device, look up the relevant entity and include its name in the changed_by details. For example:

*   For a keypad change, include the name of the access code that was
    used.
*   For a mobile device change, include the name of the user (a.k.a.
    "virtual key") that initiated the change.