### PR TITLE
Remove direct dependency on pytest.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-pytest==7.2.1
 pytest-asyncio==0.20.3
 pytest-homeassistant-custom-component==0.13.3
 pyschlage==2023.3.1


### PR DESCRIPTION
We'll pull this in via pytest-homeassistant-custom-component instead so we don't have conflicts when dependabot sends version bumps.