### PR TITLE
Handle locks being unavailable

### DIFF
--- a/custom_components/schlage/lock.py
+++ b/custom_components/schlage/lock.py
@@ -67,6 +67,8 @@ class SchlageLock(CoordinatorEntity, LockEntity):
 
     def _update_attrs(self) -> None:
         self._attr_name = f"{self._lock.name} Lock"
+        # When is_locked is None the lock is unavailable.
+        self._attr_available = self._lock.is_locked is not None
         self._attr_is_locked = self._lock.is_locked
         self._attr_is_jammed = self._lock.is_jammed
         self._attr_device_info = DeviceInfo(

--- a/custom_components/schlage/manifest.json
+++ b/custom_components/schlage/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dknowles2/ha-schlage/issues",
   "requirements": [
-    "pyschlage==2023.4.0"
+    "pyschlage==2023.4.1"
   ],
-  "version": "2023.4.0"
+  "version": "2023.4.1"
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 pytest-homeassistant-custom-component==0.13.19
-pyschlage==2023.3.2
+pyschlage==2023.4.1


### PR DESCRIPTION
This should fix #56 by bumping pyschlage to handle this condition better. We also explicitly set the `available` attribute on the lock to make sure that HA understands that you can't send the lock commands.