### PR TITLE
Raise an issue about custom component deprecation

### DIFF
--- a/custom_components/schlage/__init__.py
+++ b/custom_components/schlage/__init__.py
@@ -11,6 +11,7 @@ from pyschlage.user import User
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, LOGGER, PLATFORMS
@@ -25,6 +26,18 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Schlage from a config entry."""
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated",
+        breaks_in_ha_version="2024.9.0",
+        is_fixable=False,
+        is_persistent=True,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated",
+    )
+
     hass.data.setdefault(DOMAIN, {})
 
     auth = await hass.async_add_executor_job(

--- a/custom_components/schlage/translations/en.json
+++ b/custom_components/schlage/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "title" : "Schlage Locks",
+  "title": "Schlage Locks",
   "config": {
     "step": {
       "user": {
@@ -18,6 +18,12 @@
     },
     "abort": {
       "already_configured": "Schlage is already configured"
+    }
+  },
+  "issues": {
+    "deprecated": {
+      "title": "The Schlage custom integration is deprecated",
+      "description": "The Schlage integration will be native to Home Assistant starting with version 2023.9.0, and the custom integration will no longer be supported at that point.\n\nPlease remove the custom integration from your Home Assistant instance and then add hte integration back using the native Home Assistant workflow.\n\nThe custom integration will be removed from Github in October 2023."
     }
   }
 }


### PR DESCRIPTION
Starting with Home Assistant 2023.9.0, the Schlage integration is included with Home Assistant. Users need to remove their custom component install and then re-add it using the normal workflow.